### PR TITLE
Move build status markdown to new line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# sync-ios-app [![Build Status](https://travis-ci.org/feedhenry-templates/sync-ios-app.png)](https://travis-ci.org/feedhenry-templates/sync-ios-app)
+# sync-ios-app
+[![Build Status](https://travis-ci.org/feedhenry-templates/sync-ios-app.png)](https://travis-ci.org/feedhenry-templates/sync-ios-app)
 
 Author: Corinne Krych   
 Level: Intermediate  


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/FH-3422

Motivation: Studio cannot convert the markdown if it's on the same line as the header